### PR TITLE
bugfix: do not overrule local ignore patterns 

### DIFF
--- a/configs/lint-staged/lib/lint-staged.config.js
+++ b/configs/lint-staged/lib/lint-staged.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-    "*.{,m}js": ["eslint --ignore-pattern '!*' --fix"],
+    "*.{,m}js": ["eslint --fix"],
     "*.md": ["prettier --write"],
     "*.ts{,x}": ["eslint --fix"],
     "*.vue{,x}": ["eslint --fix"],


### PR DESCRIPTION
…defined in (eg.) .eslintrc.js and .eslintignore files

This lead to an error in linting `.eslintrc.js` itself which then subsequently leads to impossible commit.

Alternatively one could "re-ignore" `.eslintrc.js` again by using `"eslint --ignore-pattern '!*' --ignore-pattern '.eslintrc.js' --fix"` as command. I am unsure which of both options is more correct.